### PR TITLE
typo on equation and text

### DIFF
--- a/causal-inference-for-the-brave-and-true/07-Beyond-Confounders.ipynb
+++ b/causal-inference-for-the-brave-and-true/07-Beyond-Confounders.ipynb
@@ -147,7 +147,7 @@
     "Since the data is random, you know that a simple difference in means estimates the Average Treatment Effect. In other words, nothing can have caused the treatment but the randomisation, so the potential outcomes are independent of the treatment: \\\\((Y_0, Y_1)\\perp T\\\\). \n",
     "\n",
     "$\n",
-    "ATE = E[Y_i|T_i=1] - E[Y_i|T_i=1]\n",
+    "ATE = E[Y_i|T_i=1] - E[Y_i|T_i=0]\n",
     "$\n",
     "\n",
     "Since you are smart and want to place a confidence interval around your estimate, you use a linear regression."

--- a/causal-inference-for-the-brave-and-true/10-Matching.ipynb
+++ b/causal-inference-for-the-brave-and-true/10-Matching.ipynb
@@ -165,7 +165,7 @@
     "\n",
     "![img](./data/img/matching/its-a-match.png)\n",
     "\n",
-    "The subclassification estimator isn't used much in practice (we will see why shortly, it is because of the course of dimensionality) but it gives us a nice intuition of what a causal inference estimator should do, how it should control for confounders. This allows us to explore other kinds of estimators, such as the Matching Estimator. \n",
+    "The subclassification estimator isn't used much in practice (we will see why shortly, it is because of the curse of dimensionality) but it gives us a nice intuition of what a causal inference estimator should do, how it should control for confounders. This allows us to explore other kinds of estimators, such as the Matching Estimator. \n",
     "\n",
     "The idea is very similar. Since some sort of confounder X makes it so that treated and untreated are not initially comparable, I can make them so by **matching each treated unit with a similar untreated unit**. It is like I'm finding an untreated twin for every treated unit. By making such comparisons, treated and untreated become again comparable. \n",
     "\n",

--- a/causal-inference-for-the-brave-and-true/10-Matching.ipynb
+++ b/causal-inference-for-the-brave-and-true/10-Matching.ipynb
@@ -1408,7 +1408,7 @@
     "\n",
     "![img](./data/img/matching/ubiquitous-ols.png)\n",
     "\n",
-    "First of all, this linear regression that we are fitting doesn't extrapolate on the treatment dimension to get the treatment effect. Instead, its purpose is just to correct bias. Linear regression here is local, in the sense that it doesn't try to see how the treated would be if it looked like the untread. It does none of that extrapolation. This is left to the matching part. The meat of the estimator is still the matching component. The point I want to make here is that OLS is secondary to this estimator. \n",
+    "First of all, this linear regression that we are fitting doesn't extrapolate on the treatment dimension to get the treatment effect. Instead, its purpose is just to correct bias. Linear regression here is local, in the sense that it doesn't try to see how the treated would be if it looked like the untreated. It does none of that extrapolation. This is left to the matching part. The meat of the estimator is still the matching component. The point I want to make here is that OLS is secondary to this estimator. \n",
     "\n",
     "The second point is that matching is a non-parametric estimator. It doesn't assume linearity or any kind of parametric model. As such, it is more flexible than linear regression and can work in situations where linear regression will not, namely, those where non linearity is very strong.\n",
     "\n",


### PR DESCRIPTION
Solve https://github.com/matheusfacure/python-causality-handbook/issues/62 and minor typo