### PR TITLE
Corrected formula in Chapter 20.

### DIFF
--- a/causal-inference-for-the-brave-and-true/20-Plug-and-Play-Estimators.ipynb
+++ b/causal-inference-for-the-brave-and-true/20-Plug-and-Play-Estimators.ipynb
@@ -52,7 +52,7 @@
     "If we estimate this model, we can get estimates for $\\tau(x)$\n",
     " \n",
     "$\n",
-    "\\hat{\\tau}(x) = \\hat{\\beta}_1 + \\hat{\\beta}_3 t_i X_i\n",
+    "\\hat{\\tau}(x) = \\hat{\\beta}_1 + \\hat{\\beta}_3 X_i\n",
     "$\n",
     " \n",
     "Still, the linear models have some drawbacks. The main one being the linearity assumption on $X$. Notice that you don't even care about $\\beta_2$ on this model. But if the features $X$ don't have a linear relationship with the outcome, your estimates of the causal parameters $\\beta_1$ and $\\beta_3$ will be off. \n",


### PR DESCRIPTION
The treatment flag (t_i) must not be part of uplift estimate. The affected formula is derived from the previous formula in the following way:
\hat{\tau}(x) 
= y_i(t_i=1) - y_i(t_i=0)
= \beta_0 + 1 \beta_1 + \beta_2 X_i + 1 \beta_3 X_i + e_i
\- (\beta_0 + 0 \beta_1 + \beta_2 X_i + 0 \beta_3 X_i + e_i)
= 1 \beta_1 + 1 \beta_3 X_i
\- (0 \beta_1 + 0 \beta_3 X_i)
= \beta_1 + \beta_3 X_i,

i.e. t_i should just be removed from the formula. 

IMO, this error is a copy-paste issue, when the previous formula including t_i was copied, some elements deleted but not all of them.

Fixes #210
