### PR TITLE
Remove duplicate line of code

### DIFF
--- a/causal-inference-for-the-brave-and-true/11-Propensity-Score.ipynb
+++ b/causal-inference-for-the-brave-and-true/11-Propensity-Score.ipynb
@@ -724,7 +724,7 @@
     "\n",
     "print(\"Y1:\", y1)\n",
     "print(\"Y0:\", y0)\n",
-    "print(\"ATE\", np.mean(weight * data_ps[\"achievement_score\"]))"
+    "print(\"ATE\", ate)"
    ]
   },
   {


### PR DESCRIPTION
ATE is recalculated again in the print statement even though a variable called `ate` is already defined a few lines earlier.