### PR TITLE
fix typo in meta learners

### DIFF
--- a/causal-inference-for-the-brave-and-true/21-Meta-Learners.ipynb
+++ b/causal-inference-for-the-brave-and-true/21-Meta-Learners.ipynb
@@ -210,7 +210,7 @@
     "To do so, we will simply include the treatment as a feature in the model that tries to predict the outcome Y. \n",
     "\n",
     "```note\n",
-    "Although I'll use a regressor to estimate $E[Y| T, X]$, since the outcome variable is binary, you could also use a classified. Just be sure to adapt the code so that the model outputs probabilities instead of the binary class, 0, 1.\n",
+    "Although I'll use a regressor to estimate $E[Y| T, X]$, since the outcome variable is binary, you could also use a classifier. Just be sure to adapt the code so that the model outputs probabilities instead of the binary class, 0, 1.\n",
     "```"
    ]
   },


### PR DESCRIPTION
Fix small typo in meta learners notebook.
Before: 
```since the outcome variable is binary, you could also use a classified.```
After:
```since the outcome variable is binary, you could also use a classifier.```