### PR TITLE
Fix `y_star_cont` calculation code & a small typo

### DIFF
--- a/causal-inference-for-the-brave-and-true/20-Plug-and-Play-Estimators.ipynb
+++ b/causal-inference-for-the-brave-and-true/20-Plug-and-Play-Estimators.ipynb
@@ -767,8 +767,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "y_star_cont = (train[\"price\"] - train[\"price\"].mean()\n",
-    "               *train[\"sales\"] - train[\"sales\"].mean())"
+    "y_star_cont = (train[\"price\"] - train[\"price\"].mean()) * (train[\"sales\"] - train[\"sales\"].mean())"
    ]
   },
   {
@@ -927,7 +926,7 @@
     "\n",
     "plt.plot(gain_curve_test, label=\"Test\")\n",
     "plt.plot(gain_curve_train, label=\"Train\")\n",
-    "plt.plot([0, 100], [0, elast(test, \"sales\", \"price\")], linestyle=\"--\", color=\"black\", label=\"Taseline\")\n",
+    "plt.plot([0, 100], [0, elast(test, \"sales\", \"price\")], linestyle=\"--\", color=\"black\", label=\"Baseline\")\n",
     "plt.legend();"
    ]
   },
@@ -1013,7 +1012,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.11.9"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
Hi, thanks for putting out this great information source for free.

I believe there is a calculation error for `y_star_cont` in the notebook [20 - Plug-and-Play Estimators](https://matheusfacure.github.io/python-causality-handbook/20-Plug-and-Play-Estimators.html#contribute):

The formula:
![image](https://github.com/user-attachments/assets/3f3ba0ac-56cd-4d4c-b152-b0983b455df7)

The code:
```
y_star_cont = (train["price"] - train["price"].mean()
               *train["sales"] - train["sales"].mean())
```

The code above ends up calculating $$T_i - (M(T_i) * Y_i) - \bar{Y}$$.

I believe this is why the subsequent CATE estimates are very large in magnitude:
![image](https://github.com/user-attachments/assets/0c806564-ed33-4ee9-802e-e4c78424267b)

After the applying the fix in the commit & re-running the code, the CATE estimates turn out smaller in magnitude, and the cumulative gain curve changes a bit, though I didn't commit the re-ran version of the notebook to keep the diff short. Also fixed a small typo in the cumulative gain curve plot.
![image](https://github.com/user-attachments/assets/cfa9ccce-0aa3-48f6-8307-f8402444f0ec)
![image](https://github.com/user-attachments/assets/c6dd3f32-29b6-44df-af17-04bd2ab8fa76)