### PR TITLE
Update Chapter 20 binary case target transformation typo in formula

### DIFF
--- a/causal-inference-for-the-brave-and-true/20-Plug-and-Play-Estimators.ipynb
+++ b/causal-inference-for-the-brave-and-true/20-Plug-and-Play-Estimators.ipynb
@@ -105,7 +105,7 @@
     "Also, we know that\n",
     "\n",
     "$\n",
-    "Y_i*T_i = Y(1)_i*T_i \\text{ and }  Y_i*(1-T_i) = Y(0)_i*T_i\n",
+    "Y_i*T_i = Y(1)_i*T_i \\text{ and }  Y_i*(1-T_i) = Y(0)_i*(1-T_i)\n",
     "$\n",
     "\n",
     "because the treatment is what materializes one or the other potential outcomes. With that in mind, let's take the expected value of $Y^*_i$ and see what we end up with. \n",


### PR DESCRIPTION
I believe there is a typo in one of the formulas for the binary treatment target transformation, where

$Y_i*(1-T_i) = Y(0)_i*T_i$

should be

$Y_i*(1-T_i) = Y(0)_i*(1-T_i)$

Later in the demo, the correct form of the formula is used.