### PR TITLE
Distinguish mediator adjustment from collider bias

### DIFF
--- a/causal-inference-for-the-brave-and-true/04-Graphical-Causal-Models.ipynb
+++ b/causal-inference-for-the-brave-and-true/04-Graphical-Causal-Models.ipynb
@@ -691,7 +691,7 @@
     "1. It contains a non collider that has been conditioned on\n",
     "2. It contains a collider that has not been conditioned on and has no descendants that have been conditioned on.\n",
     "\n",
-    "Here is a cheat sheet about how dependence flows in a graph. I've taken from a [Stanford presentation](http://ai.stanford.edu/~paskin/gm-short-course/lec2.pdf) by Mark Paskin.  The arrows with lines at their tips signify independence, and the arrows without lines at their tips signify dependence.\n",
+    "Here is a cheat sheet about how dependence flows in a graph. I've taken it from a [Stanford presentation](http://ai.stanford.edu/~paskin/gm-short-course/lec2.pdf) by Mark Paskin.  The arrows with lines at their tips signify independence, and the arrows without lines at their tips signify dependence.\n",
     "\n",
     "![img](data/img/graph-flow.png)\n",
     "\n",
@@ -1521,7 +1521,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Imagine that investments and education take only 2 values to demonstrate why this is the case. Whether people invest or not. They are either educated or not. Initially, when we don't control for investments, the bias term is zero: $E[Y_0|T=1] - E[Y_0|T=0] = 0$ because the education was randomised. This means that the wage people would have if they didn't receive education $Wage_0$ is the same if they do or don't receive the education treatment. But what happens if we condition on investments?\n",
+    "Imagine that investments and education take only 2 values to demonstrate why this is the case. Whether people invest or not. They are either educated or not. Initially, when we don't control for investments, the bias term is zero: $E[Y_0|T=1] - E[Y_0|T=0] = 0$ because the education was randomised. This means that the average wage under no education, $E[Wage_0]$, is the same in the group assigned to education and the group not assigned to it. For someone who receives education, $Wage_0$ is counterfactual; for someone who does not, it is observed. But what happens if we condition on investments?\n",
     "\n",
     "Looking at those who invest, we probably have the case that $E[Y_0|T=0, I=1] > E[Y_0|T=1, I=1]$. In words, among those who invest, the ones who manage to do so even without education are more likely to achieve high earnings, regardless of their education level. For this reason, the wage those people have, $Wage_0|T=0$, is probably higher than the wage the educated group would have if they didn't have education, $Wage_0|T=1$. A similar reasoning can be applied to those who don't invest, where we also probably have $E[Y_0|T=0, I=0] > E[Y_0|T=1, I=0]$. Those who don't invest even with education probably would have a lower wage, had they not got the education, than those who didn't invest but didn't have an education. \n",
     "\n",
@@ -1626,7 +1626,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "A similar thing happens when we condition on a mediator of the treatment. A mediator is a variable between the treatment and the outcome. It, well, mediates the causal effect. For example, suppose again you can randomize education. But, just to be sure, you decide to control whether or not the person had a white-collar job. Once again, this conditioning biasses the causal effect estimation. This time, not because it opens a front door path with a collider, but because it closes one of the channels through which the treatment operates. In our example, getting a white-collar job is one way more education leads to higher pay. By controlling it, we close this channel and leave open only the direct effect of education on wages."
+    "Something different happens when we condition on a mediator of the treatment. A mediator is a variable between the treatment and the outcome. It, well, mediates the causal effect. For example, suppose again you can randomize education and then decide to control whether or not the person had a white-collar job. In the graph below, white-collar employment is **not** a collider. Conditioning on it blocks the indirect path $Educ \\rightarrow WC \\rightarrow Wage$ and leaves the direct path $Educ \\rightarrow Wage$ open.\n",
+    "\n",
+    "This does not automatically bias the estimation of every causal quantity. Instead, it changes the question. Without conditioning on white-collar employment, the randomized comparison identifies the **total effect** of education, including the part mediated by getting a white-collar job. An intervention that holds white-collar employment fixed targets a **controlled direct effect**. If the goal is still the total effect, the direct effect answers the wrong question; this is often called overadjustment bias. But the direct effect can be a perfectly meaningful target of its own."
    ]
   },
   {
@@ -1757,11 +1759,19 @@
     ]
    },
    "source": [
-    "To give a potential outcome argument, we know that, due to randomisation, the bias is zero $E[Y_0|T=0] - E[Y_0|T=1] = 0$. However, if we condition on the white-collar individuals, we have that $E[Y_0|T=0, WC=1] > E[Y_0|T=1, WC=1]$. That is because those who manage to get a white-collar job even without education are probably more hard-working than those who require the help of education to get the same job. With the same reasoning, $E[Y_0|T=0, WC=0] > E[Y_0|T=1, WC=0]$ because those that didn't get a white-collar job even with an education are probably less hard-working than those that didn't, but also didn't have any education. \n",
+    "Potential outcomes make the change of question explicit. Let $WC(t)$ be white-collar employment under education level $t$, and let $Y(t, m)$ be the wage under education level $t$ if white-collar employment were set to $m$. The total effect compares the outcomes along the two natural mediator paths:\n",
     "\n",
-    "In our case, conditioning on the mediator induces a negative bias. It makes the effect of education seem lower than it actually is. This is the case because the causal effect is positive. If the effect were negative, conditioning on a mediator would have a positive bias. In all cases, this sort of conditioning makes the effect look weaker than it is. \n",
+    "$$E[Y(1, WC(1)) - Y(0, WC(0))].$$\n",
     "\n",
-    "To put it more prosaic way, suppose that you have to choose between two candidates for a job at your company. Both have equally impressive professional achievements, but one does not have a higher education degree. Which one should you choose? Of course, you should go with the one without the higher education because he managed to achieve the same things as the other one but had the odds stacked against him.\n",
+    "A controlled direct effect instead holds the mediator at one value and compares\n",
+    "\n",
+    "$$E[Y(1, m) - Y(0, m)].$$\n",
+    "\n",
+    "These are different estimands. Also, simply conditioning on the observed mediator identifies a direct effect only under additional assumptions about the mediator-outcome relationship; randomizing education alone is not enough.\n",
+    "\n",
+    "For example, suppose an unobserved trait $U$, such as motivation, causes both white-collar employment and wages. The graph would then contain the path $Educ \\rightarrow WC \\leftarrow U \\rightarrow Wage$. On this path, white-collar employment is a collider. Conditioning on it opens the path and makes education and motivation associated within levels of white-collar employment, even if education was randomized. This is a separate source of bias from blocking the mediated path, and it requires the extra arrows $U \\rightarrow WC$ and $U \\rightarrow Wage$ that are not in the graph above.\n",
+    "\n",
+    "Nor does mediator adjustment always make an effect look weaker. The direct and indirect effects can have different signs, so blocking the mediated path may decrease or increase the estimate. The important thing is to decide whether the target is a total or a direct effect before choosing which variables to control for.\n",
     "\n",
     "![image.png](./data/img/causal-graph/three_bias.png)\n",
     "\n",
@@ -1769,7 +1779,7 @@
     "\n",
     "We've studied graphical models as a language to better understand and express causality ideas. We did a quick summary of the rules of conditional independence on a graph. This helped us then explore three structures that can lead to bias.\n",
     "\n",
-    "The first was confounding, which happens when treatment and outcome have a common cause that we don't account for or control for. The second is selection bias due to conditioning on a common effect. The third structure is also a form of selection bias, this time due to excessive controlling of mediator variables. This excessive controlling could lead to bias even if the treatment was randomly assigned. Selection bias can often be fixed by simply doing nothing, which is why it is dangerous. Since we are biased toward action, we tend to see ideas that control things as clever when they can be doing more harm than good. \n",
+    "The first was confounding, which happens when treatment and outcome have a common cause that we don't account for or control for. The second was selection bias due to conditioning on a common effect. The third was overadjustment: controlling for a mediator blocks part of the causal effect and changes the estimand from a total effect to a direct effect. If the total effect is our target, that change creates bias relative to the target. A mediator can also be a collider when it has a common cause with the outcome, but that requires a different graph. Since we are biased toward action, we tend to see ideas that control for more things as clever when they can be doing more harm than good. \n",
     "\n",
     "## References\n",
     "\n",


### PR DESCRIPTION
## Summary

- distinguish conditioning on a mediator from conditioning on a collider
- explain total effects and controlled direct effects with explicit potential-outcome estimands
- state why randomized treatment alone does not identify a direct effect after conditioning on an observed mediator
- show the additional graph under which a mediator can also act as a collider
- clarify that blocking an indirect path need not always attenuate the estimate
- add explaining-away terminology to the earlier collider example

## Why this matters

The previous discussion treated the white-collar employment mediator as though conditioning on it necessarily opened a collider path. In the displayed graph, it instead blocks the mediated causal path and changes the estimand from a total effect to a direct effect. Collider bias arises only after adding another cause of both the mediator and outcome. Keeping these mechanisms separate is essential for choosing an adjustment set and interpreting the resulting estimate.

## Validation

- built the full Jupyter Book successfully
- validated the notebook JSON and checked the diff for whitespace errors
- confirmed that only four markdown cells changed and no stored outputs changed

Closes #424
Closes #462
Closes #467